### PR TITLE
remove unused and broken import

### DIFF
--- a/lib/App/adler32.pm
+++ b/lib/App/adler32.pm
@@ -12,7 +12,7 @@ use Getopt::Long::Descriptive;
 
 
 use utf8;
-use Digest::Adler32 qw(adler32);
+use Digest::Adler32;
 
 =pod
 


### PR DESCRIPTION
The module was attempting to import an adler32 function from Digest::Adler32. This function was unused, which is good because the import was ignored. Digest::Adler32 does not export any functions. On future versions of perl, this will be an error.